### PR TITLE
fix import path in pointer-tool.coffee

### DIFF
--- a/src/pointer-tool.coffee
+++ b/src/pointer-tool.coffee
@@ -1,4 +1,4 @@
-Utils = require './Utils'
+Utils = require './utils'
 
 module.exports =
 class PointerTool


### PR DESCRIPTION
Loading module `utils' in pointer-tool.{coffee,js} failed on linux due to case sensitivity of its file system.
